### PR TITLE
API uploads images via URL

### DIFF
--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -15,7 +15,11 @@ module Spree
 
       def create
         authorize! :create, Image
-        @image = scope.images.create(image_params)
+        if valid_url? image_params[:attachment]
+          @image = scope.images.create(attachment: open(image_params[:attachment]))
+        else
+          @image = scope.images.create(image_params)
+        end
         respond_with(@image, status: 201, default_template: :show)
       end
 
@@ -43,6 +47,13 @@ module Spree
         elsif params[:variant_id]
           Spree::Variant.find(params[:variant_id])
         end
+      end
+
+      def valid_url?(url)
+        uri = URI.parse url
+        uri.is_a?(URI::HTTP) && !uri.host.blank?
+        rescue URI::InvalidURIError
+        false
       end
     end
   end

--- a/api/spec/requests/spree/api/images_controller_spec.rb
+++ b/api/spec/requests/spree/api/images_controller_spec.rb
@@ -17,20 +17,34 @@ module Spree
 
     context "as an admin" do
       sign_in_as_admin!
+      context "can upload a new image"
+        it "for a variant" do
+          expect do
+            post spree.api_product_images_path(product.id), params: {
+              image: {
+                attachment: upload_image('thinking-cat.jpg'),
+                viewable_type: 'Spree::Variant',
+                viewable_id: product.master.to_param
+              },
+            }
+            expect(response.status).to eq(201)
+            expect(json_response).to have_attributes(attributes)
+          end.to change(Image, :count).by(1)
+        end
 
-      it "can upload a new image for a variant" do
-        expect do
-          post spree.api_product_images_path(product.id), params: {
-            image: {
-              attachment: upload_image('thinking-cat.jpg'),
-              viewable_type: 'Spree::Variant',
-              viewable_id: product.master.to_param
-            },
-          }
-          expect(response.status).to eq(201)
-          expect(json_response).to have_attributes(attributes)
-        end.to change(Image, :count).by(1)
-      end
+        it "from a valid URL" do
+          expect do
+            post spree.api_product_images_path(product.id), params: {
+              image: {
+                attachment: 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png',
+                viewable_type: 'Spree::Variant',
+                viewable_id: product.master.to_param
+              },
+            }
+            expect(response.status).to eq(201)
+            expect(json_response).to have_attributes(attributes)
+          end.to change(Image, :count).by(1)
+        end
 
       context "working with an existing product image" do
         let!(:product_image) { product.master.images.create!(attachment: image('thinking-cat.jpg')) }


### PR DESCRIPTION
This enhancement give the images API the ability to create images from URLs.  A
simple check determines whether or not the attachment parameter is a URL.  If it
is a URL, OpenURI is used to download the image and it subsequently undergoes
the standard post upload processing (via paperclip).  If it is not a URL, then
the attachment parameter is handled in the same manner it was prior to this
commit.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
